### PR TITLE
GitHub workflow for yarn lint and package updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Linting, Testing, Building
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-and-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run linting and formatting
+        run: yarn lint
+
+      - name: Build TypeScript
+        run: yarn build
+
+      - name: Check build artifacts
+        run: ls -la dist/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,7 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+      - id: check-json
   # TODO - sort out the dep installation, npm cache dirs are getting in the way
   # - repo: local
   #   hooks:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "playwright-junit-reporter",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+
+  "version": "0.0.1",
   "packageManager": "yarn@1.22.22",
   "license": "MIT",
   "devDependencies": {
@@ -17,8 +17,19 @@
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.39.0"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "tsc",
-    "lint": "eslint . --fix && prettier . --write"
-  }
+    "lint": "eslint . --fix && prettier . --write",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "files": [ "dist" ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts"
 }


### PR DESCRIPTION
Running yarn linting consistently locally and through pre-commit.ci within pre-commit is a bit painful right now.

Just run a simple workflow to yarn install, lint, and build

Update package.json with details